### PR TITLE
Add basic web chat interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "start": "node dist/server.js"
   },
   "keywords": [],
   "author": "",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trade Agent Chat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div class="max-w-2xl mx-auto p-4 min-h-screen flex flex-col">
+      <h1 class="text-2xl font-bold mb-4 text-center">Trade Agent Chat</h1>
+      <div id="messages" class="flex-1 overflow-y-auto mb-4 space-y-2"></div>
+      <form id="chat-form" class="flex space-x-2">
+        <input
+          id="input"
+          type="text"
+          class="flex-1 border rounded px-2 py-2"
+          placeholder="Type a message..."
+          required
+        />
+        <button
+          type="submit"
+          class="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+    <script>
+      const messagesEl = document.getElementById('messages');
+      const form = document.getElementById('chat-form');
+      const input = document.getElementById('input');
+
+      function appendMessage(role, text) {
+        const wrapper = document.createElement('div');
+        wrapper.className = role === 'user' ? 'text-right' : 'text-left';
+        const span = document.createElement('span');
+        span.className = role === 'user'
+          ? 'inline-block bg-blue-500 text-white px-3 py-1 rounded-lg'
+          : 'inline-block bg-gray-200 px-3 py-1 rounded-lg';
+        span.textContent = text;
+        wrapper.appendChild(span);
+        messagesEl.appendChild(wrapper);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+        return span;
+      }
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const message = input.value.trim();
+        if (!message) return;
+        appendMessage('user', message);
+        input.value = '';
+
+        const botSpan = appendMessage('bot', '');
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message })
+        });
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          botSpan.textContent += decoder.decode(value);
+          messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+      });
+    </script>
+  </body>
+</html>
+

--- a/src/my_agent.ts
+++ b/src/my_agent.ts
@@ -12,7 +12,7 @@ dotenv.config();
 
 const WALLET_DATA_FILE = "wallet_data.txt";
 
-async function initializeAgent() {
+export async function initializeAgent() {
   const llm = new ChatOpenAI({
     model: "gpt-4o-mini", // Replace or adjust the model if desired
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,74 @@
+import http from "http";
+import fs from "fs";
+import path from "path";
+import { initializeAgent } from "./my_agent";
+import { HumanMessage } from "@langchain/core/messages";
+
+const PORT = parseInt(process.env.PORT || "3000");
+const publicDir = path.join(__dirname, "..", "public");
+
+// Initialize the agent once at startup
+const agentPromise = initializeAgent();
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === "GET" && req.url === "/") {
+    const indexPath = path.join(publicDir, "index.html");
+    fs.readFile(indexPath, (err, data) => {
+      if (err) {
+        res.statusCode = 500;
+        return res.end("Error loading page");
+      }
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(data);
+    });
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/api/chat") {
+    let body = "";
+    req.on("data", chunk => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { message } = JSON.parse(body);
+        if (!message) {
+          res.statusCode = 400;
+          return res.end("Message required");
+        }
+
+        const { agent, config } = await agentPromise;
+        res.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Transfer-Encoding": "chunked",
+        });
+
+        const stream = await agent.stream(
+          { messages: [new HumanMessage(message)] },
+          config
+        );
+
+        for await (const chunk of stream) {
+          let text = "";
+          if ("agent" in chunk) {
+            text = chunk.agent.messages[0].content;
+          } else if ("tools" in chunk) {
+            text = chunk.tools.messages[0].content;
+          }
+          res.write(text);
+        }
+        res.end();
+      } catch (err) {
+        res.statusCode = 500;
+        res.end("Server error");
+      }
+    });
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end("Not found");
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- add Tailwind-styled chat frontend streaming replies
- create HTTP server for /api/chat and static files
- export agent initializer and add start script

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d4c6b1c048333bec830fdf202f679